### PR TITLE
fix order and update IRSA module

### DIFF
--- a/docs/getting-started/getting-your-attendee-information.md
+++ b/docs/getting-started/getting-your-attendee-information.md
@@ -52,11 +52,11 @@ Depending on your class, your instructor will let you know which Sysdig region t
 
 Depending on your class, your instructor will let you know which AWS region to use.
 
-  | Account Name | Account ID | Region |
-  |--------------|------------|--------|
-  | sysdig-kraken-hunter-us | 905418274209 | us-west-1 |
-  | sysdig-kraken-hunter-eu | 339712937206 | eu-central-1 |
-  | sysdig-kraken-hunter-ap | 381492038270 | ap-southeast-2 |
+  | Account Name | Account ID | Region | Region Name |
+  |--------------|------------|--------|-------------|
+  | sysdig-kraken-hunter-us | 905418274209 | us-west-1 | US West (N. California) |
+  | sysdig-kraken-hunter-eu | 339712937206 | eu-central-1 | EU (Frankfurt) |
+  | sysdig-kraken-hunter-ap | 381492038270 | ap-southeast-2 | AP (Sydney) |
 
 ## Completed
 

--- a/docs/learning-paths/full-kraken-hunter.md
+++ b/docs/learning-paths/full-kraken-hunter.md
@@ -15,10 +15,10 @@ In this learning path, you will learn how to use Sysdig to detect and prevent th
 
 1. [Getting Started]({{site.baseurl}}/docs/getting-started/)
 2. **Runtime Threat Detection**
-    1. **Runtime Threat Detection - Cloud**
+    1. [Runtime Threat Detection in Kubernetes]({{site.baseurl}}/docs/modules/runtime-threat-detection/runtime-threat-detection-kubernetes/index.html)
+    2. **Runtime Threat Detection - Cloud**
         1. [CloudTrail Detections]({{site.baseurl}}/docs/modules/runtime-threat-detection/runtime-threat-detection-cloud/cloudtrail-detections.html)
         2. [Exploiting Overpermissioned EKS Workloads]({{site.baseurl}}/docs/modules/runtime-threat-detection/runtime-threat-detection-cloud/eks-iam-roles-and-irsa.html)
-    2. [Runtime Threat Detection in Kubernetes]({{site.baseurl}}/docs/modules/runtime-threat-detection/runtime-threat-detection-kubernetes/index.html)
 3. **Vulnerability Management**
     1. [Pipeline Vulnerability Scanning]({{site.baseurl}}/docs/modules/vulnerability-management/pipeline.html)
     2. [Runtime Vulnerability Scanning]({{site.baseurl}}/docs/modules/vulnerability-management/runtime.html)

--- a/docs/learning-paths/kubernetes.md
+++ b/docs/learning-paths/kubernetes.md
@@ -12,7 +12,7 @@ nav_order: 2
 Kubernetes is a complex system that can be difficult to configure, use, and secure. This learning path will help you understand how to use Sysdig to detect and prevent threats in your Kubernetes environments.
 
 1. [Getting Started]({{site.baseurl}}/docs/getting-started/)
-2. [Exploiting Overpermissioned EKS Workloads]({{site.baseurl}}/docs/modules/runtime-threat-detection/runtime-threat-detection-cloud/eks-iam-roles-and-irsa.html)
-3. [Runtime Threat Detection in Kubernetes]({{site.baseurl}}/docs/modules/runtime-threat-detection/runtime-threat-detection-kubernetes/index.html)
+2. [Runtime Threat Detection in Kubernetes]({{site.baseurl}}/docs/modules/runtime-threat-detection/runtime-threat-detection-kubernetes/index.html)
+3. [Exploiting Overpermissioned EKS Workloads]({{site.baseurl}}/docs/modules/runtime-threat-detection/runtime-threat-detection-cloud/eks-iam-roles-and-irsa.html)
 4. [Kubernetes Posture Management]({{site.baseurl}}/docs/modules/kubernetes/kubernetes-posture-management.html)
 5. [Kubernetes Network Policies]({{site.baseurl}}/docs/modules/kubernetes/kubernetes-network-policies.html)

--- a/docs/modules/runtime-threat-detection/runtime-threat-detection-cloud/eks-iam-roles-and-irsa.md
+++ b/docs/modules/runtime-threat-detection/runtime-threat-detection-cloud/eks-iam-roles-and-irsa.md
@@ -20,7 +20,6 @@ We've prepared an IRSA mapping already - the **irsa** ServiceAccount in the **se
 
 ```bash
 sudo bash; cd ~
-./set-up-irsa.sh
 kubectl get serviceaccount irsa -n security-playground -o yaml
 ```
 
@@ -69,7 +68,7 @@ You'll also note that, if you look at the trust relationships of the IAM Role in
 
 ## The Exploit
 
-If we install the AWS CLI into our container at runtime and run some commands we'll see if our Pod has been assigned an IRSA role and they succeed. There is an **02-01-example-curls-bucket-public.sh** file in `/root` - have a look at it
+If we install the AWS CLI into our container at runtime and run some commands we'll see if our Pod has been assigned an IRSA role and they succeed. There is an **02-01-example-curls-bucket-public.sh** file in `/root`. Have a look at it and run it.
 
 ```bash
 sudo bash; cd ~
@@ -77,19 +76,21 @@ cat 02-01-example-curls-bucket-public.sh
 ./02-01-example-curls-bucket-public.sh
 ```
 
-The install of the AWS CLI succeeds but the S3 changes fail as we don't have that access. We have an updated manifest for the security-playground Deployment that will use this **irsa** ServiceAccount instead of the **default** one we have been using. Apply that by running:
+The install of the AWS CLI succeeds but the S3 changes fail as we don't have that access. We have an updated manifest for the security-playground Deployment that will use this **irsa** ServiceAccount instead of the **default** one we have been using. 
+
+Apply the IRSA ServiceAccount by running:
 
 ```bash
-kubectl apply -f 02-cfg-security-playground-irsa.yaml
+./set-up-irsa.sh
 ```
 
-to apply that change. Now re-run:
+Now re-run the script:
 
 ```bash
 ./02-01-example-curls-bucket-public.sh
 ```
 
-and this time they will work!
+This time they will work!
 
 ## The Sysdig Detections
 


### PR DESCRIPTION
* Order still matters for some of the original KH modules, so swapped order in "Full-Day Kraken Hunter" Learning path
* I'm not sure the IRSA section was ever working properly, as the first command to run altered the workload before it was supposed to be altered, so now it will first review the current setup, then run the setup-irsa script, then re-run the check to see what changed